### PR TITLE
add .gitlab-ci.yml in order to use ci/cd in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,26 @@
+stages:
+  - build
+
+variables:
+  CONTAINER_IMAGE: ergw/vpp-test
+  CONTAINER_IMAGE_BUILT: ${CONTAINER_IMAGE}:${CI_COMMIT_REF_SLUG}_${CI_COMMIT_SHA}
+  CONTAINER_IMAGE_LATEST: ${CONTAINER_IMAGE}:latest
+  CI_REGISTRY: index.docker.io  # container registry URL
+  CI_REGESTRY_IMAGE: https://index.docker.io/v1/
+
+
+# build container image
+build:
+  stage: build
+  #tags: 
+  #  - docker
+  image: docker:latest
+  services:
+  - docker:dind
+  script:
+    - export DOCKER_HOST="tcp://localhost:2375"
+    - echo "Building Dockerfile-based application..."
+    - docker build -t ${CONTAINER_IMAGE_BUILT} -f extras/docker/Dockerfile .
+    - docker login -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASSWORD}
+    - echo "Pushing to the Container Registry..."
+    - docker push ${CONTAINER_IMAGE_BUILT}


### PR DESCRIPTION
Add .gitlab-ci.yml in order to use CI/CD pipeline in GitLab.
Here we have two parts:
Github repo: Code management.
GitLab repo: CI/CD pipeline for code which is managed on Github.
Plan is continue to use Github for code management and GitLab for CI/CD pipeline.
GitLab repo : https://gitlab.com/travelping/vpp-github