### PR TITLE
Fix UPF binary API and add dump calls

### DIFF
--- a/src/plugins/upf/upf.api
+++ b/src/plugins/upf/upf.api
@@ -62,3 +62,57 @@ autoreply define upf_app_flow_timeout_set {
   u8 type;
   u16 default_value;
 };
+
+/*
+  NOTE: details must go before corresponding _dump,
+  or we'll be gettings errors like:
+
+  vl_socket_api_send:133: id out of range: 1301
+*/
+
+define upf_applications_details {
+  u32 context;
+
+  u8 name[64];
+  u32 flags;
+};
+
+define upf_applications_dump {
+  u32 client_index;
+  u32 context;
+};
+
+/* TODO: ip rules aren't implemented yet */
+/*
+define upf_application_ip_rule_details {
+  u32 context;
+  u32 id;
+
+  u8 is_ipv6;
+  u8 src_ip_addr[16];
+  u8 src_ip_prefix_len;
+  u8 dst_ip_addr[16];
+  u8 dst_ip_prefix_len;
+};
+
+define upf_application_ip_rule_dump {
+  u32 client_index;
+  u32 context;
+
+  u8 app[64];
+};
+*/
+
+define upf_application_l7_rule_details {
+  u32 context;
+
+  u32 id;
+  u8 regex[1024];
+};
+
+define upf_application_l7_rule_dump {
+  u32 client_index;
+  u32 context;
+
+  u8 app[64];
+};

--- a/src/plugins/upf/upf_adf.c
+++ b/src/plugins/upf/upf_adf.c
@@ -507,7 +507,6 @@ vnet_upf_app_add_del (u8 * name, u32 flags, u8 add)
       if (!p)
 	return VNET_API_ERROR_NO_SUCH_ENTRY;
 
-      hash_unset_mem (sm->upf_app_by_name, name);
       app = pool_elt_at_index (sm->upf_apps, p[0]);
 
       if (upf_adf_adr_ref_count (app->db_index) != 0)
@@ -522,10 +521,12 @@ vnet_upf_app_add_del (u8 * name, u32 flags, u8 add)
       }));
       /* *INDENT-ON* */
 
+      hash_unset_mem (sm->upf_app_by_name, app->name);
       upf_adf_remove (app->db_index);
       vec_free (app->name);
       hash_free (app->rules_by_id);
       pool_free (app->rules);
+      clib_memset (app, 0, sizeof (*app));
       pool_put (sm->upf_apps, app);
     }
 
@@ -650,6 +651,7 @@ vnet_upf_rule_add_del (u8 * app_name, u32 rule_index, u8 add, regex_t regex)
       rule = pool_elt_at_index (app->rules, p[0]);
       vec_free (rule->regex);
       hash_unset (app->rules_by_id, rule_index);
+      clib_memset (rule, 0, sizeof (*rule));
       pool_put (app->rules, rule);
     }
 

--- a/src/plugins/upf/upf_api.c
+++ b/src/plugins/upf/upf_api.c
@@ -63,7 +63,8 @@
 static void
 setup_message_id_table (upf_main_t * sm, api_main_t * am)
 {
-#define _(id,n,crc)   vl_msg_api_add_msg_name_crc (am, #n  #crc, id + sm->msg_id_base);
+#define _(id,n,crc) \
+  vl_msg_api_add_msg_name_crc (am, #n "_" #crc, id + sm->msg_id_base);
   foreach_vl_msg_name_crc_upf;
 #undef _
 }
@@ -73,7 +74,9 @@ _(UPF_ENABLE_DISABLE, upf_enable_disable) \
 _(UPF_APP_ADD_DEL, upf_app_add_del) \
 _(UPF_APP_IP_RULE_ADD_DEL, upf_app_ip_rule_add_del) \
 _(UPF_APP_L7_RULE_ADD_DEL, upf_app_l7_rule_add_del) \
-_(UPF_APP_FLOW_TIMEOUT_SET, upf_app_flow_timeout_set)
+_(UPF_APP_FLOW_TIMEOUT_SET, upf_app_flow_timeout_set) \
+_(UPF_APPLICATIONS_DUMP, upf_applications_dump) \
+_(UPF_APPLICATION_L7_RULE_DUMP, upf_application_l7_rule_dump)
 
 /* API message handler */
 static void vl_api_upf_enable_disable_t_handler
@@ -96,9 +99,11 @@ vl_api_upf_app_add_del_t_handler (vl_api_upf_app_add_del_t * mp)
   vl_api_upf_app_add_del_reply_t *rmp = NULL;
   upf_main_t *sm = &upf_main;
   int rv = 0;
+  u8 *name = format(0, "%s", mp->name);
 
-  rv = upf_app_add_del (sm, mp->name, (u32) (mp->flags), (int) (mp->is_add));
+  rv = upf_app_add_del (sm, name, (u32) (mp->flags), (int) (mp->is_add));
 
+  vec_free(name);
   REPLY_MACRO (VL_API_UPF_APP_ADD_DEL_REPLY);
 }
 
@@ -109,9 +114,12 @@ static void vl_api_upf_app_ip_rule_add_del_t_handler
   vl_api_upf_app_ip_rule_add_del_reply_t *rmp = NULL;
   upf_main_t *sm = &upf_main;
   int rv = 0;
+  u8 *app = format(0, "%s", mp->app);
 
-  rv = upf_rule_add_del (sm, mp->app, mp->id, (int) (mp->is_add), NULL);
+  // TODO: ip rules aren't implemented yet
+  rv = upf_rule_add_del (sm, app, ntohl(mp->id), (int) (mp->is_add), NULL);
 
+  vec_free(app);
   REPLY_MACRO (VL_API_UPF_APP_IP_RULE_ADD_DEL_REPLY);
 }
 
@@ -122,9 +130,12 @@ static void vl_api_upf_app_l7_rule_add_del_t_handler
   vl_api_upf_app_l7_rule_add_del_reply_t *rmp = NULL;
   upf_main_t *sm = &upf_main;
   int rv = 0;
+  u8 *app = format(0, "%s", mp->app), *regex = format(0, "%s", mp->regex);
 
-  rv = upf_rule_add_del (sm, mp->app, mp->id, (int) (mp->is_add), mp->regex);
+  rv = upf_rule_add_del (sm, app, ntohl(mp->id), (int) (mp->is_add), regex);
 
+  vec_free(app);
+  vec_free(regex);
   REPLY_MACRO (VL_API_UPF_APP_L7_RULE_ADD_DEL_REPLY);
 }
 
@@ -136,9 +147,106 @@ static void vl_api_upf_app_flow_timeout_set_t_handler
   vl_api_upf_app_flow_timeout_set_reply_t *rmp = NULL;
   upf_main_t *sm = &upf_main;
 
-  //rv = upf_flow_timeout_update(mp->type, mp->default_value);
+  //rv = upf_flow_timeout_update(mp->type, ntohs(mp->default_value));
 
   REPLY_MACRO (VL_API_UPF_APP_FLOW_TIMEOUT_SET_REPLY);
+}
+
+static void
+send_upf_applications_details (vl_api_registration_t * reg,
+                               u8 * app_name, u32 flags, u32 context)
+{
+  vl_api_upf_applications_details_t *mp;
+  upf_main_t *sm = &upf_main;
+  u32 name_len;
+
+  mp = vl_msg_api_alloc (sizeof (*mp));
+  clib_memset (mp, 0, sizeof (*mp));
+
+  mp->_vl_msg_id = htons (VL_API_UPF_APPLICATIONS_DETAILS
+			  + sm->msg_id_base);
+  mp->context = context;
+
+  name_len = clib_min(vec_len(app_name) + 1, ARRAY_LEN(mp->name));
+  memcpy (mp->name, app_name, name_len-1);
+  ASSERT (0 == mp->name[name_len - 1]);
+  mp->flags = htonl(flags);
+
+  vl_api_send_msg (reg, (u8 *) mp);
+}
+
+/* API message handler */
+static void vl_api_upf_applications_dump_t_handler
+(vl_api_upf_applications_dump_t * mp)
+{
+  upf_main_t *sm = &upf_main;
+  vl_api_registration_t *reg;
+  upf_adf_app_t *app = NULL;
+
+  reg = vl_api_client_index_to_registration (mp->client_index);
+  if (!reg) {
+    return;
+  }
+
+  /* *INDENT-OFF* */
+  pool_foreach(app, sm->upf_apps,
+    ({
+      send_upf_applications_details (reg, app->name, app->flags, mp->context);
+    }));
+  /* *INDENT-ON* */
+}
+
+static void
+send_upf_application_l7_rule_details (vl_api_registration_t * reg,
+                                      u32 id, u8 * regex, u32 context)
+{
+  vl_api_upf_application_l7_rule_details_t *mp;
+  upf_main_t *sm = &upf_main;
+  u32 regex_len;
+
+  mp = vl_msg_api_alloc (sizeof (*mp));
+  clib_memset (mp, 0, sizeof (*mp));
+
+  mp->_vl_msg_id = htons (VL_API_UPF_APPLICATION_L7_RULE_DETAILS
+			  + sm->msg_id_base);
+  mp->context = context;
+
+  mp->id = htonl(id);
+  regex_len = clib_min(vec_len(regex) + 1, ARRAY_LEN(mp->regex));
+  memcpy (mp->regex, regex, regex_len-1);
+  ASSERT (0 == mp->regex[regex_len - 1]);
+
+  vl_api_send_msg (reg, (u8 *) mp);
+}
+
+/* API message handler */
+static void vl_api_upf_application_l7_rule_dump_t_handler
+(vl_api_upf_application_l7_rule_dump_t * mp)
+{
+  upf_main_t *sm = &upf_main;
+  vl_api_registration_t *reg;
+  upf_adf_app_t *app = NULL;
+  upf_adr_t *rule = NULL;
+  u8 *app_name = format(0, "%s", mp->app);
+  uword *p = NULL;
+
+  reg = vl_api_client_index_to_registration (mp->client_index);
+  if (!reg) {
+    return;
+  }
+
+  p = hash_get_mem (sm->upf_app_by_name, app_name);
+  if (!p)
+    return;
+
+  app = pool_elt_at_index (sm->upf_apps, p[0]);
+
+  /* *INDENT-OFF* */
+  pool_foreach(rule, app->rules,
+               ({
+                 send_upf_application_l7_rule_details (reg, rule->id, rule->regex, mp->context);
+               }));
+  /* *INDENT-ON* */
 }
 
 /* Set up the API message handling tables */


### PR DESCRIPTION
Fix string handling in the API. They were being confused with vectors.
Fix deletion of applications. The hash key was being removed too
early.
Add upf_applications_dump and upf_application_l7_rule_dump calls
to make it possible to do proper sync with the controller.