### PR TITLE
Add upf_update_app binary API for UPF

### DIFF
--- a/src/plugins/upf/upf.api
+++ b/src/plugins/upf/upf.api
@@ -63,6 +63,23 @@ autoreply define upf_app_flow_timeout_set {
   u16 default_value;
 };
 
+/* TODO: use this struct for adding and dumping the rules */
+typedef upf_l7_rule
+{
+  u32 id;
+  u32 regex_length;
+  u8 regex[regex_length];
+};
+
+autoreply define upf_update_app {
+  u32 client_index;
+  u32 context;
+
+  u8 app[64];
+  u32 l7_rule_count;
+  vl_api_upf_l7_rule_t l7_rules[l7_rule_count];
+};
+
 /*
   NOTE: details must go before corresponding _dump,
   or we'll be gettings errors like:

--- a/src/plugins/upf/upf_adf.h
+++ b/src/plugins/upf/upf_adf.h
@@ -59,6 +59,9 @@ int upf_rule_add_del (upf_main_t * sm, u8 * name, u32 id,
 u32 upf_adf_get_adr_db (u32 application_id);
 void upf_adf_put_adr_db (u32 db_index);
 
+int upf_update_app (upf_main_t * sm, u8 * app_name, u32 num_rules,
+                    u32 * ids, u32 * regex_lengths, u8 ** regexes);
+
 /* perfect hash over the HTTP keywords:
  *   GET
  *   PUT

--- a/src/plugins/upf/upf_api.c
+++ b/src/plugins/upf/upf_api.c
@@ -247,6 +247,8 @@ static void vl_api_upf_application_l7_rule_dump_t_handler
                  send_upf_application_l7_rule_details (reg, rule->id, rule->regex, mp->context);
                }));
   /* *INDENT-ON* */
+
+  vec_free(app_name);
 }
 
 /* Set up the API message handling tables */


### PR DESCRIPTION
This API call does bulk update of the app rules,
recompiling the regexps just once.
Also, fix memory leak in the UPF binary API