### PR TITLE
upf: fix ipfilter port field on D/L direction

### DIFF
--- a/src/plugins/upf/upf_pfcp.c
+++ b/src/plugins/upf/upf_pfcp.c
@@ -1474,8 +1474,8 @@ compile_sdf (int is_ip4, const upf_pdr_t * pdr,
 			 pdr, rule, acl);
       ip_assign_address (UPF_ACL_FIELD_DST, IPFILTER_RULE_FIELD_DST, is_ip4,
 			 pdr, rule, acl);
-      ip_assign_port (UPF_ACL_FIELD_DST, IPFILTER_RULE_FIELD_SRC, rule, acl);
-      ip_assign_port (UPF_ACL_FIELD_SRC, IPFILTER_RULE_FIELD_DST, rule, acl);
+      ip_assign_port (UPF_ACL_FIELD_SRC, IPFILTER_RULE_FIELD_SRC, rule, acl);
+      ip_assign_port (UPF_ACL_FIELD_DST, IPFILTER_RULE_FIELD_DST, rule, acl);
       break;
     }
 }


### PR DESCRIPTION
Field ordering for port has to match the ordering of the
IPs. Make them match for filters in D/L direction.

Fixes #59.

Change-Id: I3f7958ea12d270ade7a8fafab890cfa4e3d0b6a8