### PR TITLE
Feature/2005/upf worker mode crash

### DIFF
--- a/init.conf
+++ b/init.conf
@@ -35,6 +35,8 @@ upf nwi name sgi vrf 2
 upf gtpu endpoint ip 172.21.16.1 nwi cp teid 0x80000000/2
 upf gtpu endpoint ip 172.20.16.105 nwi epc teid 0x80000000/2
 
+upf enable proxy
+
 create upf application proxy name Gold
 upf application Gold rule 1 add l7 regex ^http://172.20.16.75/Gold/.*$
 upf application Gold rule 2 add l7 regex ^https://dmock/.*$

--- a/src/plugins/upf/upf_proxy.c
+++ b/src/plugins/upf/upf_proxy.c
@@ -1065,12 +1065,27 @@ upf_proxy_main_init (vlib_main_t * vm)
     vlib_node_add_next (vm, tcp6_output_node.index,
 			upf_ip6_proxy_server_output_node.index);
 
-  upf_proxy_create (0, 1);
-
   return 0;
 }
 
 VLIB_INIT_FUNCTION (upf_proxy_main_init);
+
+static clib_error_t *
+upf_enable_proxy_command_fn (vlib_main_t * vm,
+			     unformat_input_t * input,
+			     vlib_cli_command_t * cmd)
+{
+  clib_error_t *error = NULL;
+  upf_proxy_create (0, 1);
+  return error;
+}
+
+VLIB_CLI_COMMAND (upf_enable_proxy_command, static) =
+{
+  .path = "upf enable proxy",
+  .short_help = "upf enable proxy",
+  .function = upf_enable_proxy_command_fn,
+};
 
 /*
 * fd.io coding-style-patch-verification: ON


### PR DESCRIPTION
Hello,
The UPF Proxy component causes a segfault which crashes the VPP node when using UPF with worker configuration (multi threading)

i.e
```
cpu {
  workers 1
}
```

This commit adds a command that will allow to postponed the create UPF Proxy after the VPP node is loaded. When we postponed the create UPF Proxy function the node does not crash.

As this is my first contribution to your project, i'm not very familiar with the project architecture, interdependencies between all components, and conventions. Moreover I'm not sure how to test this specific functionality E2E to make sure nothing is broken, so please review and let me know if anything is missing or if you have any concerns.

Br.
